### PR TITLE
feat: job summary table, dry-run support, and "nothing to be done" message

### DIFF
--- a/src/snakemake_logger_plugin_rich/event_handler.py
+++ b/src/snakemake_logger_plugin_rich/event_handler.py
@@ -371,6 +371,10 @@ class EventHandler:
             pass
         self.total_jobs = event_data.total_job_count
 
+        self._display_job_summary(
+            event_data.per_rule_job_counts, event_data.total_job_count
+        )
+
         if self.total_jobs > 0:
             self.total_progress_task = self.progress_display.add_or_update(
                 "Total Progress", 0, self.total_jobs
@@ -391,6 +395,37 @@ class EventHandler:
                     "started": 0,
                 }
                 self.progress_display.add_or_update(rule, 0, count, visible=False)
+
+    def _display_job_summary(
+        self, per_rule_job_counts: Dict[str, int], total_job_count: int
+    ) -> None:
+        """Render the per-rule job summary (snakemake's "Job stats" table).
+
+        Printed to the console (not the transient progress display) so it stays
+        visible after the run, giving a persistent record of what was scheduled.
+        Shown for both real and dry runs.
+        """
+        if not per_rule_job_counts:
+            return
+
+        table = Table(
+            title="Job stats",
+            title_style="bold",
+            title_justify="left",
+            box=box.SIMPLE_HEAD,
+            header_style="bold blue",
+            pad_edge=False,
+        )
+        table.add_column("rule", justify="left", style="blue")
+        table.add_column("count", justify="right")
+
+        for rule, count in per_rule_job_counts.items():
+            table.add_row(prettyprint_rule(rule), str(count))
+
+        table.add_section()
+        table.add_row("total", str(total_job_count), style="bold")
+
+        self.console.print(table)
 
     def _register_started_job(self, rule_name: str) -> None:
         """Account for a job that is about to run, registering rules that were

--- a/src/snakemake_logger_plugin_rich/event_handler.py
+++ b/src/snakemake_logger_plugin_rich/event_handler.py
@@ -243,6 +243,12 @@ class EventHandler:
             "log": event_data.log,
         }
 
+        if self.dryrun:
+            # No job actually runs, so there is no progress to update; just list
+            # what would run and why, mirroring snakemake's dry-run output.
+            self._display_dryrun_job(event_data)
+            return
+
         self._register_started_job(event_data.rule_name)
         self.progress_display.set_visible(event_data.rule_name, True)
         self.progress_display.update_active(event_data.rule_name)
@@ -375,6 +381,12 @@ class EventHandler:
             event_data.per_rule_job_counts, event_data.total_job_count
         )
 
+        if self.dryrun:
+            # Nothing executes in a dry run, so there is no progress to track.
+            # The job summary above and the per-job listing (handle_job_info)
+            # are the whole output; skip starting the live progress display.
+            return
+
         if self.total_jobs > 0:
             self.total_progress_task = self.progress_display.add_or_update(
                 "Total Progress", 0, self.total_jobs
@@ -426,6 +438,25 @@ class EventHandler:
         table.add_row("total", str(total_job_count), style="bold")
 
         self.console.print(table)
+
+    def _display_dryrun_job(self, event_data: events.JobInfo) -> None:
+        """List a single job that would run, with its reason (dry-run mode).
+
+        Uses a "Would run" label mirroring the "Started"/"Finished" prefixes of a
+        real run. No timestamp is shown since nothing actually executes.
+        """
+        lines = [
+            f"[bold light_steel_blue]◌ Would run[/] {event_data.rule_name} "
+            f"[dim](id: {event_data.jobid})[/]"
+        ]
+        if event_data.rule_msg:
+            lines.append(f"[italic]{event_data.rule_msg}[/]")
+        wc = format_wildcards(event_data.wildcards)
+        if wc:
+            lines.append(f"[light_steel_blue]Wildcards:[/] {wc}")
+        if event_data.reason:
+            lines.append(f"[light_steel_blue]Reason:[/] [dim]{event_data.reason}[/]")
+        self.console.print("\n    ".join(lines), end="\n\n")
 
     def _register_started_job(self, rule_name: str) -> None:
         """Account for a job that is about to run, registering rules that were
@@ -522,6 +553,12 @@ class EventHandler:
             env_path = conda_done_match.group(1)
             env_name = Path(env_path).name
             self._complete_conda_status(env_name)
+            return
+
+        if message.startswith("This was a dry-run"):
+            # Closing footer snakemake emits at the end of `-n`; no "Complete
+            # log" line is produced in a dry run, so surface this instead.
+            self.console.print(f"\n[yellow]●[/] {message}")
             return
 
         if message.startswith("Nothing to be done"):

--- a/src/snakemake_logger_plugin_rich/event_handler.py
+++ b/src/snakemake_logger_plugin_rich/event_handler.py
@@ -489,6 +489,13 @@ class EventHandler:
             self._complete_conda_status(env_name)
             return
 
+        if message.startswith("Nothing to be done"):
+            # Snakemake emits this as a plain info log (no LogEvent) when every
+            # requested file is already present and up to date. Surface it so the
+            # run does not appear to end without explanation.
+            self.console.print(f"[green]✓[/] {message}")
+            return
+
         if "Complete log" in message:
             self.console.rule("Workflow Finished", style="green")
             self.console.print(

--- a/tests/test_demo_workflow.py
+++ b/tests/test_demo_workflow.py
@@ -53,6 +53,62 @@ def test_demo_workflow():
             pytest.fail("Snakemake command timed out after 5 minutes")
 
 
+def test_dryrun_mode():
+    """Test that a dry run lists the jobs that would run, with their reasons.
+
+    Nothing executes in a dry run, so there are no job-started/-finished events
+    and no progress display. The logger should instead list each scheduled job
+    (rule, wildcards, reason) and print snakemake's dry-run footer.
+    """
+
+    project_root = Path(__file__).parent.parent
+    test_snakefile = project_root / "tests" / "fixtures" / "Snakefile"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir) / "demo_output"
+        output_dir.mkdir()
+
+        cmd = [
+            "snakemake",
+            "-n",
+            "-s",
+            str(test_snakefile),
+            "-d",
+            str(output_dir),
+            "--logger",
+            "rich",
+            "--cores",
+            "1",
+            "output.txt",
+        ]
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+            assert result.returncode == 0, (
+                f"Dry-run snakemake failed with return code "
+                f"{result.returncode}.\nSTDOUT: {result.stdout}\n"
+                f"STDERR: {result.stderr}"
+            )
+
+            output = result.stdout + result.stderr
+            # per-job listing with reasons, and the dry-run footer
+            assert "Reason:" in output, (
+                "The rich logger did not list job reasons in dry-run mode.\n"
+                f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+            )
+            assert "This was a dry-run" in output, (
+                "The rich logger did not print the dry-run footer.\n"
+                f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+            )
+            assert "create_input" in output, (
+                "The rich logger did not list the scheduled jobs in dry-run "
+                f"mode.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+            )
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("Snakemake command timed out after 5 minutes")
+
+
 def test_nothing_to_be_done():
     """Test that the "nothing to be done" message is displayed when up to date.
 
@@ -83,9 +139,7 @@ def test_nothing_to_be_done():
 
         try:
             # first run builds all outputs
-            first = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=300
-            )
+            first = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
             assert first.returncode == 0, (
                 f"Initial snakemake run failed with return code "
                 f"{first.returncode}.\nSTDOUT: {first.stdout}\n"
@@ -93,9 +147,7 @@ def test_nothing_to_be_done():
             )
 
             # second run: everything is up to date
-            second = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=300
-            )
+            second = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
             assert second.returncode == 0, (
                 f"Up-to-date snakemake run failed with return code "
                 f"{second.returncode}.\nSTDOUT: {second.stdout}\n"

--- a/tests/test_demo_workflow.py
+++ b/tests/test_demo_workflow.py
@@ -53,6 +53,66 @@ def test_demo_workflow():
             pytest.fail("Snakemake command timed out after 5 minutes")
 
 
+def test_nothing_to_be_done():
+    """Test that the "nothing to be done" message is displayed when up to date.
+
+    Snakemake emits this as a plain info log (no LogEvent) once all requested
+    files are present and up to date. The rich logger used to drop it silently,
+    making an up-to-date run look like it ended without explanation.
+    """
+
+    project_root = Path(__file__).parent.parent
+    test_snakefile = project_root / "tests" / "fixtures" / "Snakefile"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir) / "demo_output"
+        output_dir.mkdir()
+
+        cmd = [
+            "snakemake",
+            "-s",
+            str(test_snakefile),
+            "-d",
+            str(output_dir),
+            "--logger",
+            "rich",
+            "--cores",
+            "1",
+            "output.txt",
+        ]
+
+        try:
+            # first run builds all outputs
+            first = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=300
+            )
+            assert first.returncode == 0, (
+                f"Initial snakemake run failed with return code "
+                f"{first.returncode}.\nSTDOUT: {first.stdout}\n"
+                f"STDERR: {first.stderr}"
+            )
+
+            # second run: everything is up to date
+            second = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=300
+            )
+            assert second.returncode == 0, (
+                f"Up-to-date snakemake run failed with return code "
+                f"{second.returncode}.\nSTDOUT: {second.stdout}\n"
+                f"STDERR: {second.stderr}"
+            )
+
+            output = second.stdout + second.stderr
+            assert "Nothing to be done" in output, (
+                "The rich logger did not display the 'Nothing to be done' "
+                f"message on an up-to-date run.\nSTDOUT: {second.stdout}\n"
+                f"STDERR: {second.stderr}"
+            )
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("Snakemake command timed out after 5 minutes")
+
+
 def test_checkpoint_workflow():
     """Test that a workflow using checkpoints runs without breaking the logger.
 


### PR DESCRIPTION
This PR improves the logger's output in a few common situations where it previously showed little or nothing.

## Changes

- **Job summary table.** Render snakemake's "Job stats" (per-rule job counts plus a total) as a rich table on run info. The plugin already received these counts but used them only to seed the transient progress bars, so nothing persistent showed what was scheduled. The table is printed to the console so it survives after the run.
- **Dry-run support.** In a dry run nothing executes, so there are no job-started/-finished events and no progress to track. The logger now lists each scheduled job (rule, id, message, wildcards, and reason) with a `Would run` label mirroring the `Started`/`Finished` prefixes of a real run, skips the live progress display, and surfaces snakemake's `This was a dry-run` footer. The two stats tables sandwich the job list, as the default logger does.
- **"Nothing to be done" message.** Snakemake emits this as a plain info log with no LogEvent, so it reached `handle_generic_record`, which had no branch for it and dropped it silently. An up-to-date run therefore looked like it ended without explanation; it is now displayed.

## Tests

Adds `test_nothing_to_be_done` and `test_dryrun_mode` to the existing subprocess-based workflow tests. All tests pass.

## AI usage

These changes were implemented with the assistance of Claude (Claude Code).
